### PR TITLE
Fix compilation and tests on Visual Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 a.out
 build
 xml
+*.swp

--- a/Zcode/tree/node/node.hpp
+++ b/Zcode/tree/node/node.hpp
@@ -143,6 +143,7 @@ struct Node: public definitions<Dim, node_type>
 
     inline void set_level(std::size_t lev)
     {
+        assert( lev < nlevels );
         value = (value&maskpos) + (lev<<levelshift);
     }
 

--- a/Zcode/tree/node/util.hpp
+++ b/Zcode/tree/node/util.hpp
@@ -24,29 +24,14 @@ template<int dim, typename node_type> struct AllSet2One<dim, 0, node_type>
 
 // Construction of Ones array
 // C++ 14 version
-template <typename node_type, std::size_t level>
-constexpr node_type Ones(std::size_t dim, node_type bit) {
-  return Ones<node_type, level-1>(dim, bit) + (bit>>(dim*level));
-}
-
-template <>
-constexpr unsigned short Ones<unsigned short, 0>(std::size_t dim, unsigned short bit) {
-    return bit;
-}
-
-template <>
-constexpr unsigned int Ones<unsigned int, 0>(std::size_t dim, unsigned int bit) {
-    return bit;
-}
-
-template <>
-constexpr std::size_t Ones<std::size_t, 0>(std::size_t dim, std::size_t bit) {
-    return bit;
+template <typename node_type>
+constexpr node_type Ones(std::size_t level, std::size_t dim, node_type bit) {
+  return level > 0 ? Ones(level-1, dim, bit) + ( bit >> (dim*level) ) : bit;
 }
 
 template<typename node_type, std::size_t... i>
 constexpr auto Ones_array(std::size_t dim, node_type bit, std::index_sequence<i...>) {
-    return std::array<node_type, sizeof...(i)>{{Ones<node_type, i>(dim, bit)...}};
+    return std::array<node_type, sizeof...(i)>{{ Ones<node_type>(i, dim, bit)... }};
 }
 
 template<std::size_t size, typename node_type>

--- a/Zcode/tree/node/util.hpp
+++ b/Zcode/tree/node/util.hpp
@@ -6,10 +6,10 @@
 /// Generate a number with all digits in range (0,n-1) set to one
 ///  (metaprogram).
 ///
-/// Use it like: 
+/// Use it like:
 ///
 ///  static const int k=AllSet2One<n>:value;
-///  with n=3, this gives k=7. 
+///  with n=3, this gives k=7.
 ///
 /// \brief generate a number with digits (0,n-1) set to 1.
 ////////////////////////////////////////////////////////////////////////
@@ -66,7 +66,7 @@ constexpr auto Stencil_array() {
 constexpr std::size_t max_level(std::size_t const dim, std::size_t  const freebits, std::size_t  const size)
 {
   std::size_t tmp = size - freebits, level = 0;
-  
+
   while (tmp/dim > (1 << level))
   {
     tmp--;

--- a/Zcode/tree/slot/slot.hpp
+++ b/Zcode/tree/slot/slot.hpp
@@ -21,10 +21,10 @@ void myreplace_if(ForwardIt first, ForwardIt last,
 ///
 /// \brief slot structures, store a set of Nodes.
 ////////////////////////////////////////////////////////////////////////////
-template<std::size_t dim, typename value_type=std::size_t> 
-struct slot: private std::vector<Node<dim, value_type>>
+template < std::size_t dim, typename node_value_type = std::size_t > 
+struct slot: private std::vector< Node<dim, node_value_type> >
 {
-    using node_type = Node<dim, value_type>;
+    using node_type = Node<dim, node_value_type>;
     using parent = std::vector<node_type>;
     using parent::operator[];
     using parent::push_back;
@@ -40,10 +40,10 @@ struct slot: private std::vector<Node<dim, value_type>>
     using parent::capacity;
     using parent::shrink_to_fit;
 
-    static const value_type FreeBitsPart = node_type::FreeBitsPart;
-    static const value_type voidbit = node_type::voidbit;
-    static const value_type maskpos = node_type::maskpos;
-    static const value_type decal = dim*node_type::nlevels;
+    static const node_value_type FreeBitsPart = node_type::FreeBitsPart;
+    static const node_value_type voidbit = node_type::voidbit;
+    static const node_value_type maskpos = node_type::maskpos;
+    static const node_value_type decal = dim*node_type::nlevels;
 
     node_type s1{0}, s2{node_type::AllOnes[node_type::nlevels-1]};
 
@@ -195,7 +195,7 @@ public:
     //! \param mark for the test.
     bool markedOther(node_type mark)
     {
-        node_type N{static_cast<value_type>(FreeBitsPart-mark.value)};
+        node_type N{static_cast<node_value_type>(FreeBitsPart-mark.value)};
         const unsigned char m = (N.value&FreeBitsPart)>>decal;
         return slotMark&m;
     }
@@ -377,8 +377,8 @@ public:
     void restore(std::ifstream& f)
     {
         std::size_t ssize; 
-        value_type ss1;
-        value_type ss2;
+        node_value_type ss1;
+        node_value_type ss2;
         f >> ssize;
         f >> ss2; 
         f >> ss1; 
@@ -387,7 +387,7 @@ public:
         s2 = ss2; 
         for(std::size_t j=0; j<ssize; j++)
         {
-            value_type N;
+            node_value_type N;
             f >> N;
             put(node_type{N});
         }
@@ -395,8 +395,8 @@ public:
     
 };
 
-template<std::size_t dim, typename value_type>
-std::ostream& operator<<(std::ostream& os, const slot<dim, value_type>& sl)
+template<std::size_t dim, typename node_value_type>
+std::ostream& operator<<(std::ostream& os, const slot<dim, node_value_type>& sl)
 {
     os << "slot\n";
     os << "s1: " << sl.s1 << "\n";

--- a/Zcode/tree/slot/slotCollection.hpp
+++ b/Zcode/tree/slot/slotCollection.hpp
@@ -11,15 +11,15 @@
 #include <tree/slot/cache.hpp>
 
 
-template<std::size_t dim, typename value_type>
-struct slotCollection:private std::vector<std::shared_ptr<slot<dim, value_type>>>,
-                      public definitions<dim, value_type>
-// struct slotCollection:private std::vector<slot<dim, value_type>>,
-//                       public definitions<dim, value_type>
+template < std::size_t dim, typename node_value_type >
+struct slotCollection : private std::vector< std::shared_ptr< slot<dim, node_value_type> > >,
+                        public definitions<dim, node_value_type>
+// struct slotCollection:private std::vector<slot<dim, node_value_type>>,
+//                       public definitions<dim, node_value_type>
 {
-    using slot_type = slot<dim, value_type>;
+    using slot_type = slot<dim, node_value_type>;
     using node_type = typename slot_type::node_type;
-    using definition = definitions<dim, value_type>;
+    using definition = definitions<dim, node_value_type>;
 
     using definition::nlevels;
     using definition::AllOnes;
@@ -42,14 +42,14 @@ struct slotCollection:private std::vector<std::shared_ptr<slot<dim, value_type>>
 
 
     // static const std::size_t nlevels = node_type::nlevels;
-    // static constexpr std::array<value_type, nlevels> AllOnes = node_type::AllOnes;
+    // static constexpr std::array<node_value_type, nlevels> AllOnes = node_type::AllOnes;
 
     //static const std::size_t sizestt=SLOTCOLLECTION_SIZESTT;
 
     std::array<std::size_t, nlevels+1> countlev;//! used to count the Nodes level by level
     std::size_t breaksize;//!< size of slot which triggers decomposition of a slot.
     //! cache used to avoid repetitive search of slots.
-    Cache<dim, value_type> cache;
+    Cache<dim, node_value_type> cache;
     std::size_t countNodes;//!< number of Nodes stored in slots.
     std::size_t maxslotsize;//! maximum size of slots stored.
     std::size_t dupsize;//!< size of slot which triggers fusion of two slots.
@@ -148,7 +148,7 @@ struct slotCollection:private std::vector<std::shared_ptr<slot<dim, value_type>>
     //! store one node.
     //! \param x Node
     //! \param cach this version  uses an external Cache (this is thread safe)
-    inline void put(node_type x, Cache<dim, value_type>& cach)
+    inline void put(node_type x, Cache<dim, node_value_type>& cach)
     {
         node_type xh = x.hash(), xabs = xh&node_type::maskpos;
         auto stloc = cach.find(xabs);
@@ -225,7 +225,7 @@ struct slotCollection:private std::vector<std::shared_ptr<slot<dim, value_type>>
     //! \param cach cache updated.
     //! \note we do not directly check if the Node is really non hashed, but
     // this is checked in "xh=hash(x)".
-    inline bool find(node_type x, Cache<dim, value_type>& cach) const
+    inline bool find(node_type x, Cache<dim, node_value_type>& cach) const
     {
         node_type xh = x.hash(), xabs = xh&node_type::maskpos;
         auto stloc = cach.find(xabs);
@@ -336,8 +336,8 @@ struct slotCollection:private std::vector<std::shared_ptr<slot<dim, value_type>>
 
 };
 
-template<std::size_t dim, typename value_type>
-std::ostream& operator<<(std::ostream& os, const slotCollection<dim, value_type>& st)
+template<std::size_t dim, typename node_value_type>
+std::ostream& operator<<(std::ostream& os, const slotCollection<dim, node_value_type>& st)
 {
     os << "slotCollection\n";
     os << st.smax << "\n";

--- a/test/test_node.cpp
+++ b/test/test_node.cpp
@@ -39,8 +39,7 @@ struct NodeTest: public ::testing::Test {
     }
 };
 
-//typedef ::testing::Types<DIM_GROUP(unsigned short), DIM_GROUP(unsigned int), DIM_GROUP(std::size_t)> NodeTypes;
-typedef ::testing::Types<DIM_GROUP(unsigned int), DIM_GROUP(std::size_t)> NodeTypes;
+typedef ::testing::Types<DIM_GROUP(unsigned short), DIM_GROUP(unsigned int), DIM_GROUP(std::size_t)> NodeTypes;
 TYPED_TEST_CASE(NodeTest, NodeTypes);
 
 TYPED_TEST(NodeTest, constructor)
@@ -107,7 +106,7 @@ TYPED_TEST(NodeTest, brothers)
     using value_type = typename TestFixture::value_type;
     using node_type = Node<dim, value_type>;
 
-    for(std::size_t level=0; level<4; ++level)
+    for ( std::size_t level = 0; level < node_type::nlevels; ++level)
     {
         std::cout << "set node\n";
         node_type node{};

--- a/test/test_node.cpp
+++ b/test/test_node.cpp
@@ -108,13 +108,9 @@ TYPED_TEST(NodeTest, brothers)
 
     for ( std::size_t level = 0; level < node_type::nlevels; ++level)
     {
-        std::cout << "set node\n";
         node_type node{};
-        std::cout << "set array\n";
         std::array<node_type, ipow(2, dim)> b;
-        std::cout << "pow: " << ipow(2, dim) << "\n";
         node.set_level(level);
-        std::cout << "set_level\n";
         brothers(node, b);
         auto btrue = TestFixture::build_brothers(level);
         for (std::size_t i = 0; i<btrue.size(); ++i)


### PR DESCRIPTION
- renaming `value_type` template parameter in `slot` and `slotCollection` classes. For Visual Studio, it was hidden, inside the class body, by the `value_type` type alias of the base class `std::vector`. Don't know what the standard says about this but it is quite surprising... Anyway, we should maybe adopt a specific naming scheme for the template parameters, like `valueType` or `TValue`, to avoid conflict with type aliases.
- modifying `Ones_array` implementation to avoid template specialization collisions on x86 target (default target in Visual Studio) and to avoid the specialization for all known types.
- fixing failure of 'test_node.cpp' due to the usage of 4 levels on `unsigned short` that supports only 3 levels. Don't know why there is no assert in `std::array` implementation of GNU and Clang on Linux platform...

