### PR TITLE
Fixing some warnings with -Wall option

### DIFF
--- a/Zcode/tree/node/node.hpp
+++ b/Zcode/tree/node/node.hpp
@@ -91,7 +91,7 @@ struct Node: public definitions<Dim, node_type>
         auto bit = dummy.first;
         auto mask = dummy.second;
         node_type tmp = (maskpos - mask);
-        node_type keep = value&tmp + (value&levelzone);
+        node_type keep = (value&tmp) + (value&levelzone);
 
         node_type dec = 0;
         for (std::size_t i=0; i<stencil; ++i)
@@ -158,7 +158,7 @@ struct Node: public definitions<Dim, node_type>
     //! \note we do not check V.
     inline void setTags(Node &n) const
     {
-        n.value = ((n.value)&partWithoutFreeBits) + value&FreeBitsPart;
+        n.value = ((n.value)&partWithoutFreeBits) + (value&FreeBitsPart);
     }
 
     //! return the hash code for nodes.
@@ -230,7 +230,7 @@ std::ostream& operator<<(std::ostream &os, const Node<dim, value_type> &node)
 
     node_type IntOne{1};//!<! 1! 
 
-    for(int i=size-1;i>=0;i--)
+    for( std::size_t i = size-1; i >= 0; i-- )
     {
         if(node&(IntOne<<i))
             s+='1';

--- a/Zcode/tree/node/node.hpp
+++ b/Zcode/tree/node/node.hpp
@@ -230,7 +230,7 @@ std::ostream& operator<<(std::ostream &os, const Node<dim, value_type> &node)
 
     node_type IntOne{1};//!<! 1! 
 
-    for( std::size_t i = size-1; i >= 0; i-- )
+    for( int i = size-1; i >= 0; i-- )
     {
         if(node&(IntOne<<i))
             s+='1';
@@ -241,7 +241,7 @@ std::ostream& operator<<(std::ostream &os, const Node<dim, value_type> &node)
         //else if(i==levelshift ||i==size-1)
         else if(i==levelshift)
             s+='.';
-        else if(i%dim==0 && i>0 && i<dim*nlevels)
+        else if ( i%dim == 0 && i > 0 && static_cast<std::size_t>(i) < dim*nlevels)
             s+='.';
     }
 

--- a/Zcode/tree/node/util.hpp
+++ b/Zcode/tree/node/util.hpp
@@ -82,7 +82,7 @@ constexpr std::size_t max_level(std::size_t const dim, std::size_t  const freebi
 {
   std::size_t tmp = size - freebits, level = 0;
   
-  while (tmp/dim > (1 << level))
+  while (tmp/dim > (1ul << level))
   {
     tmp--;
     level++;

--- a/Zcode/tree/slot/cache.hpp
+++ b/Zcode/tree/slot/cache.hpp
@@ -32,8 +32,10 @@ struct Cache
     {
         auto index = std::find_if(st.cbegin(), st.cend(), [&](auto &n){return (hashN>=n.s1 && hashN<n.s2);});
         if (index != st.end())
+        {
             current = std::distance(st.begin(), index);
             return st[current];
+        }
         return nullptr;
     }
 

--- a/Zcode/tree/slot/slotCollection.hpp
+++ b/Zcode/tree/slot/slotCollection.hpp
@@ -73,10 +73,10 @@ struct slotCollection:private std::vector<std::shared_ptr<slot<dim, value_type>>
                    std::size_t _slotsize, 
                    std::size_t _dupsize, 
                    std::size_t _breaksize):
-                   dupsize{_dupsize},
-                   breaksize{_breaksize},
-                   smax{AllOnes[nlevels-1]},
-                   countNodes{0}
+        breaksize{_breaksize},
+        countNodes{0},
+        dupsize{_dupsize},
+        smax{AllOnes[nlevels-1]}
     {
         reserve(_nslots);
         push_back(std::make_shared<slot_type>(0, smax, _slotsize));
@@ -85,10 +85,10 @@ struct slotCollection:private std::vector<std::shared_ptr<slot<dim, value_type>>
 
     // remark: this copy constructor doesn't set the same capacity of the copied slotCollection
     slotCollection(slotCollection const& SC):
-        dupsize{SC.dupsize},
         breaksize{SC.breaksize},
-        smax{AllOnes[nlevels-1]},
-        countNodes{SC.countNodes}
+        countNodes{SC.countNodes},
+        dupsize{SC.dupsize},
+        smax{AllOnes[nlevels-1]}
     {
         for(std::size_t i=0; i<SC.size(); ++i)
             push_back(std::make_shared<slot_type>(*SC[i]));

--- a/test/test_slot.cpp
+++ b/test/test_slot.cpp
@@ -165,7 +165,6 @@ TYPED_TEST(SlotTest, hasvoidnodes)
 {
     auto const dim = TestFixture::dim;
     using value_type = typename TestFixture::value_type;
-    using node_type = Node<dim, value_type>;
 
     slot<dim, value_type> slot{10};
     EXPECT_EQ( slot.hasvoidNodes(), false );


### PR DESCRIPTION
Some warnings about suggested parenthesis, signed/unsigned comparisons, and unordered member initialization.

Otherwise, it seems that there were missing braces around an `if` block in `cache.hpp` (see https://github.com/rolanddenis/Zcode/commit/389a8b492fe8d6a7f904e16cae53892c47c59d54).
